### PR TITLE
libidn2 2.3.4 rebuild

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,17 +1,17 @@
+{% set name = "libidn2" %}
 {% set version = "2.3.4" %}
-{% set sha256 = "93caba72b4e051d1f8d4f5a076ab63c99b77faee019b72b9783b267986dbb45f" %}
 
 package:
-  name: libidn2
+  name: {{ name }}
   version: {{ version }}
 
 source:
-  url: https://ftp.gnu.org/gnu/libidn/libidn2-{{ version }}.tar.gz
-  sha256: "{{ sha256 }}"
+  url: https://ftp.gnu.org/gnu/libidn/{{ name }}-{{ version }}.tar.gz
+  sha256: 93caba72b4e051d1f8d4f5a076ab63c99b77faee019b72b9783b267986dbb45f
 
 build:
   skip: True  # [win]
-  number: 0
+  number: 1
   run_exports:
     # _Amazing_ backwards compatibility so pin to major number:
     #    https://abi-laboratory.pro/tracker/timeline/libidn2/
@@ -19,11 +19,12 @@ build:
 
 requirements:
   build:
+    - {{ stdlib('c') }}
     - {{ compiler('c') }}
     - make
     - pkg-config
   host:
-    - libunistring 0.9.10
+    - libunistring 1.3
 
 test:
   commands:


### PR DESCRIPTION
libidn2 2.3.4 rebuild

**Destination channel:** Default

### Links

- [PKG-9191](https://anaconda.atlassian.net/browse/PKG-9191)
- dev_url:        https://gitlab.com/libidn/libidn2/-/tree/v2.3.4?ref_type=tags
- conda_forge:    https://github.com/conda-forge/libidn2-feedstock
- pypi:           
- pypi inspector: 

### Explanation of changes:

- rebuild


[PKG-9191]: https://anaconda.atlassian.net/browse/PKG-9191?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ